### PR TITLE
Parse Links

### DIFF
--- a/parser/parser.rb
+++ b/parser/parser.rb
@@ -93,19 +93,11 @@ class WikiLink
   end
 
   def unalias(link)
-    if link.include? '|'
-      link.split('|').first
-    else
-      link
-    end
+    link.split('|').first
   end
 
   def unsection(link)
-    if link.include? '#'
-      link.split('#').first
-    else
-      link
-    end
+    link.split('#').first
   end
 
   def canonicalize(link)


### PR DESCRIPTION
I'm sure it's by no means perfect, but heres a first shot at parsing links. It only parses links from the Main/Article namespace, strips off renames (|), and section references (#), and canonicalizes the remaining link title (http://en.wikipedia.org/wiki/Help:Link#Conversion_to_canonical_form).
